### PR TITLE
'options' to 'option'.  I think this is a typo.

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -581,7 +581,7 @@
 			if(o == 'setDate'){
 				return input.datepicker(o, arguments[1]);
 			}
-			if(o == 'options' && typeof(arguments[1]) == 'string'){
+			if(o == 'option' && typeof(arguments[1]) == 'string'){
 				return input.datepicker(o, arguments[1], arguments[2]);
 			}
 			if(o == 'dialog'){


### PR DESCRIPTION
Hey Trent, quick pull request here.  I think you meant for 'options' to be 'option' - check the diff.

-Joseph, AppNexus
