### PR TITLE
Regional settings fix (solves Issue 32)

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -96,7 +96,7 @@ $.extend(Timepicker.prototype, {
 		var tp_inst = new Timepicker(),
 			inlineSettings = {};
 
-		for (var attrName in tp_inst._defaults) {
+		for (var attrName in this._defaults) {
 			var attrValue = $input.attr('time:' + attrName);
 			if (attrValue) {
 				try {
@@ -106,7 +106,7 @@ $.extend(Timepicker.prototype, {
 				}
 			}
 		}
-		tp_inst._defaults = $.extend({}, tp_inst._defaults, inlineSettings, o, {
+		tp_inst._defaults = $.extend({}, this._defaults, inlineSettings, o, {
 			beforeShow: function(input, dp_inst) {
 				tp_inst.hour = tp_inst._defaults.hour;
 				tp_inst.minute = tp_inst._defaults.minute;


### PR DESCRIPTION
Hi Trent,

I found the bug, I was copying the new instance defaults instead of the global defaults when creating a new Timepicker.

Also, I've created an 'unstable' branch in my repo where code will be in-progress.  From now on I will make pull requests properly from the stable master branch without mixing up stable and unstable code.

Cheers,

**Charles**
