### PR TITLE
Publish CSS to simplify usage

### DIFF
--- a/jquery-ui-timepicker-addon.css
+++ b/jquery-ui-timepicker-addon.css
@@ -1,0 +1,5 @@
+.ui-timepicker-div .ui-widget-header { margin-bottom: 8px; }
+.ui-timepicker-div dl { text-align: left; }
+.ui-timepicker-div dl dt { height: 25px; }
+.ui-timepicker-div dl dd { margin: -25px 0 10px 65px; }
+.ui-timepicker-div td { font-size: 90%; }

--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -8,13 +8,6 @@
 * Dual licensed under the MIT and GPL licenses.
 * http://trentrichardson.com/Impromptu/GPL-LICENSE.txt
 * http://trentrichardson.com/Impromptu/MIT-LICENSE.txt
-* 
-* HERES THE CSS:
-* .ui-timepicker-div .ui-widget-header{ margin-bottom: 8px; }
-* .ui-timepicker-div dl{ text-align: left; }
-* .ui-timepicker-div dl dt{ height: 25px; }
-* .ui-timepicker-div dl dd{ margin: -25px 0 10px 65px; }
-* .ui-timepicker-div td { font-size: 90%; }
 */
 
 (function($) {


### PR DESCRIPTION
Other projects can link the JS file but there is no way to link the CSS. The only way is to copy-paste the CSS. Publishing CSS would allow simpler usage and also future updates of the CSS.
