### PR TITLE
Adding ability to choose the timezone

### DIFF
--- a/example-timezone.html
+++ b/example-timezone.html
@@ -22,7 +22,7 @@ input { width: 200px; }
 <script type="text/javascript">
 $(document).ready(function(){
     $(".timepicktest0").datetimepicker({ dateFormat: $.datepicker.RFC_2822, timeFormat: 'hh:mm' });
-    $(".timepicktest1").datetimepicker({ dateFormat: $.datepicker.RFC_2822, timeFormat: 'hh:mm z', showTimezone: true });
+    $(".timepicktest1").datetimepicker({ dateFormat: $.datepicker.RFC_2822, timeFormat: 'hh:mm z', showTimezone: true, timezone: "+0100" });
     $(".timepicktest2").datetimepicker({ dateFormat: $.datepicker.RFC_2822, timeFormat: 'hh:mm z', showTimezone: true,
 								    timezoneList: [{"value": "+0000", "label": "British Winter Time"}, {"value": "+0100", "label": "British Summer Time"}] });
 });

--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -54,6 +54,7 @@ function Timepicker() {
 		hour: 0,
 		minute: 0,
 		second: 0,
+		timezone: '+0000',
 		hourMin: 0,
 		minuteMin: 0,
 		secondMin: 0,
@@ -409,7 +410,7 @@ $.extend(Timepicker.prototype, {
 						.text(typeof val == "object" ? val.label : val);
 				})
 			);
-			this.timezone_select.val(this.timezone);
+			this.timezone_select.val((typeof this.timezone != "undefined" && this.timezone != null && this.timezone != "") ? this.timezone : o.timezone);
 			this.timezone_select.change(function() {
 				tp_inst._onTimeChange();
 			});


### PR DESCRIPTION
I'd like to suggest another selector for the time zone, since users may be in various time zones. I've used "z" for the formatter parameter, representing a time zone indicator in the RFC 2822 format (+xxxx or -xxxx).

The additional options are:
- showTimezone: true/false
- timezone: "+0100" (used by default if the time zone is missing from the value to parse)
- timezoneList: [{"value": "+0000", "label": "British Winter Time"}, {"value": "+0100", "label": "British Summer Time"}] or, if no labels are required, simply something like ["+0100","+0200"].

The default values and the list to present could be customized depending on the user.

This includes a test HTML file.

Here is an example, with an input like this:

```
 <input type="text" value="Mon, 28 Feb 2011 10:58 +0100"/>
```

and with a datetimepicker initialized like this:

```
.datetimepicker({ dateFormat: $.datepicker.RFC_2822,
                  timeFormat: 'hh:mm z',
                  showTimezone: true,
                  timezoneList: ["+0000", "+0100"] });
```
