### PR TITLE
Pointing the "this" keyword at the date/timepicker input field

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -134,13 +134,13 @@ $.extend(Timepicker.prototype, {
 				// Update the time as well : this prevents the time from disappearing from the $input field.
 				tp_inst._updateDateTime(dp_inst);
 				if ($.isFunction(o.onChangeMonthYear))
-					o.onChangeMonthYear(year, month, dp_inst, tp_inst);
+					o.onChangeMonthYear.call($input[0], year, month, dp_inst, tp_inst);
 			},
 			onClose: function(dateText, dp_inst) {
 				if (tp_inst.timeDefined === true && $input.val() != '')
 					tp_inst._updateDateTime(dp_inst);
 				if ($.isFunction(o.onClose))
-					o.onClose(dateText, dp_inst, tp_inst);
+					o.onClose.call($input[0], dateText, dp_inst, tp_inst);
 			},
 			timepicker: tp_inst // add timepicker as a property of datepicker: $.datepicker._get(dp_inst, 'timepicker');
 		});


### PR DESCRIPTION
As I was looking through this plugin today, I noticed that two of the three Datepicker methods that are overridden by Timepicker should point the _this_ keyword at the associated input field, but were in fact not. This comes down to the different ways to call a method in JS. The docs are here:

http://jqueryui.com/demos/datepicker/#event-onClose

Notice what it says: 

> "_this_ refers to the associated input field"

This is fairly easily remedied by changing this:

<pre>o.onChangeMonthYear(year, month, dp_inst, tp_inst);</pre>


To this:

<pre>o.onChangeMonthYear.call($input[0], year, month, dp_inst, tp_inst);</pre>


If you find something wrong with this implementation, please let me know!
