### PR TITLE
parseTime regex fix for special characters

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -192,10 +192,10 @@ $.extend(Timepicker.prototype, {
 		if (!this.inst) this.inst = $.datepicker._getInst(this.$input[0]);
 
 		if (withDate || !this._defaults.timeOnly) {
-			// the time should come after x number of characters and a space.
-			// x = at least the length of text specified by the date format
-			var dp_dateFormat = $.datepicker._get(this.inst, 'dateFormat');
-			regstr = '.{' + dp_dateFormat.length + ',}' + this._defaults.separator + regstr;
+			// escape special regex characters in the seperator
+			specials = new RegExp("[.*+?|()\\[\\]{}\\\\]", "g");
+			// start matching from the end where we know the length of the time format
+			regstr = this._defaults.separator.replace(specials, "\\$&") + regstr;
 		}
 
 		treg = timeString.match(new RegExp(regstr, 'i'));


### PR DESCRIPTION
Hi, 

I made a small fix that escapes regex special characters like |()[]+?... in the time separator.  It's unlikely that anyone would use any separator other than " " for their time format.  But if they do and they use one of the special regex characters, they won't get a "NaN" parse error. 

Also, it just happens to make the regex a little simpler by matching from the end of string and ignoring the date portion in the beginning. 

Let me know what you think of this patch. 

Thanks
