### PR TITLE
setting the defaultDate fills in a value when the input is emtpy

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -721,7 +721,7 @@ $.fn.extend({
 	datetimepicker: function(o) {
 		o = o || {};
 		var $input = this,
-			tmp_args = arguments;
+		tmp_args = arguments;
 
 		if (typeof(o) == 'string'){
 			if(o == 'getDate') 
@@ -908,8 +908,8 @@ $.datepicker._setTimeDatepicker = function(target, date, withDate) {
 			}
 			else tp_date = new Date(date.getTime());
 			if (tp_date.toString() == 'Invalid Date') tp_date = undefined;
+			this._setTime(inst, tp_date);
 		}
-		this._setTime(inst, tp_date);
 	}
 
 };


### PR DESCRIPTION
Example HTML:
     <input id="timepickertest1" />

Example JavaScript:
    $("#timepickertest1").datetimepicker({
        dateFormat: $.datepicker.RFC_2822,
        timeFormat: 'hh:mm'
    });
    $("#timepickertest1").datepicker("option","defaultDate","Sun, 27 Feb 2011");

This will set populate the input value with the current date, although this should only really be the default date used when opening the datetimepicker.

The attached patch should fix this issue.
