### PR TITLE
Fix time not updating when rendering calendar inline

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -452,7 +452,7 @@ $.extend(Timepicker.prototype, {
 			if ($buttonPanel.length) $buttonPanel.before($tp);
 			else $dp.append($tp);
 
-			this.$timeObj = $('#ui_tpicker_time_'+ dp_id);
+			this.$timeObj = $tp.find('#ui_tpicker_time_'+ dp_id);
 
 			if (this.inst !== null) {
 				var timeDefined = this.timeDefined;


### PR DESCRIPTION
At the point when this was happening the element hadn't been added to the page yet. This way we can get a reference to it anyways.
