### PR TITLE
fix for disallowing user input when dateFormat is 'd M yy'

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -821,7 +821,7 @@ $.datepicker._doKeyPress = function(event) {
 								tp_inst._defaults.separator +
 								$.datepicker._possibleChars($.datepicker._get(inst, 'dateFormat')),
 				chr = String.fromCharCode(event.charCode === undefined ? event.keyCode : event.charCode);
-			return event.ctrlKey || (chr < ' ' || !datetimeChars || datetimeChars.indexOf(chr) > -1);
+			return $.datepicker._possibleChars($.datepicker._get(inst, 'dateFormat')) == null || event.ctrlKey || (chr < ' ' || !datetimeChars || datetimeChars.indexOf(chr) > -1);
 		}
 	}
 	


### PR DESCRIPTION
when datepicker contraint input returns null it means that there are no contraints. Allow the same for timepicker.
