### PR TITLE
Override parseDate() because UI 1.8.14 throws an error about "Extra characters"

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -969,6 +969,24 @@ $.datepicker._getDateDatepicker = function(target, noDefault) {
 };
 
 //#######################################################################################
+// override parseDate() because UI 1.8.14 throws an error about "Extra characters"
+// An option in datapicker to ignore extra format characters would be nicer.
+//#######################################################################################
+$.datepicker._base_parseDate = $.datepicker.parseDate;
+$.datepicker.parseDate = function(format, value, settings) {
+	var date;
+	try {
+		date = this._base_parseDate(format, value, settings);
+	} catch (err) {
+		// Hack!  The error message ends with a colon, a space, and
+		// the "extra" characters.  We rely on that instead of
+		// attempting to perfectly reproduce the parsing algorithm.
+		date = this._base_parseDate(format, value.substring(0,value.length-(err.length-err.indexOf(':')-2)), settings);
+	}
+	return date;
+};
+
+//#######################################################################################
 // jQuery extend now ignores nulls!
 //#######################################################################################
 function extendRemove(target, props) {


### PR DESCRIPTION
Override parseDate() because UI 1.8.14 throws an error about "Extra characters".
An option in datapicker to ignore extra format characters would be nicer.
I don't know how difficult it would be to negotiate an additional datepicker
option nor how long it would take to get an additional option into a stable
datepicker release.  For now, this at least keeps the timepicker addon working.
