### PR TITLE
Now button should set the current timezone.

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -991,7 +991,7 @@ $.datepicker._gotoToday = function(id) {
 	this._base_gotoToday(id);
 	var now = new Date();
 	var tp_inst = this._get(inst, 'timepicker');
-	if (tp_inst.timezone_select) {
+	if (tp_inst._defaults.showTimezone && tp_inst.timezone_select) {
 		var tzoffset = now.getTimezoneOffset(); // If +0100, returns -60
 		var tzsign = tzoffset > 0 ? '-' : '+';
 		tzoffset = Math.abs(tzoffset);


### PR DESCRIPTION
Hi,

Now button sets the datetime picker with the current time of browser, however the timezone isn't changed. I think it should be changed with the timezone of browser.
