### PR TITLE
Support timezone designators in iso8601

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1025,6 +1025,8 @@ $.datepicker._gotoToday = function(id) {
 		tzoffset = Math.abs(tzoffset);
 		var tzmin = tzoffset % 60
 		tzoffset = tzsign + ('0' + (tzoffset - tzmin) / 60).slice(-2) + ('0' + tzmin).slice(-2);
+		if (tp_inst._defaults.timezoneIso8609)
+			tzoffset = tzoffset.substring(0, 3) + ':' + tzoffset.substring(3);
 		tp_inst.timezone_select.val(tzoffset);
 	}
 	this._setTime(inst, now);


### PR DESCRIPTION
I'm working to integrate your timepicker-addon with Trac, http://trac.edgewall.org/ticket/10245.

In Trac 0.13dev, a user can select iso8601 to format/parse a datetime other than his/her locale. Now, the picker cannot only parse iso8601 timezone (e.g. `Z`, `+01:00`).

Please accept the patch if possible.
Thanks.
