### PR TITLE
Bug with default timezone not being selected

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -838,9 +838,13 @@ $.datepicker._adjustDate = function(id, offset, period) {
     this._adjustInstDate(inst, offset +
         (period == 'M' ? this._get(inst, 'showCurrentAtPos') : 0), // undo positioning
         period);
-    this._updateDatepicker(inst);
+
     this._selectDate(id, this._formatDate(inst,
         inst.selectedDay, inst.drawMonth, inst.drawYear));
+
+    $.datepicker._setDateFromField(inst);
+    $.datepicker._updateAlternate(inst);
+    $.datepicker._updateDatepicker(inst);
 };
 
 //#############################################################################################


### PR DESCRIPTION
This bug has to do with the timezone not being selected initially in the dropdown menu when the timezone is set in the options.

So even though I have 

``` javascript
        $(".datetime").datetimepicker({
            ampm: true,
            dateFormat: 'yy-mm-dd',
            timeFormat: 'hh:mm tt z',
            showTimezone: true,
            timezone: "-0700"
        });
```

The timezone is set to "+0000" in the dropdown menu.

This is the bug that I fixed.
