### PR TITLE
beforeShow fix 

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -147,7 +147,7 @@ $.extend(Timepicker.prototype, {
 		tp_inst._defaults = $.extend({}, this._defaults, inlineSettings, o, {
 			beforeShow: function(input, dp_inst) {
 				if ($.isFunction(o.beforeShow))
-					o.beforeShow(input, dp_inst, tp_inst);
+					return o.beforeShow(input, dp_inst, tp_inst);
 			},
 			onChangeMonthYear: function(year, month, dp_inst) {
 				// Update the time as well : this prevents the time from disappearing from the $input field.


### PR DESCRIPTION
Hey Trent, 

Noticed that even though I have beforeShow event added to my code and while it was returning false, DateTime picker used to popup. Digging into the code, I found that the beforeShow in your plugin did not return the value from event "beforeShow". I have added that just to make sure that beforeShow feature remains intact. 

Needless to mention, JQuery UI Datepicker uses beforeShow value to decide whether to show date picker or not.

Thanks!
Kunal 
