### PR TITLE
Fixed #303 (by jun66j5): timeFormat: 'tt h:mm' is not parsed 

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -247,7 +247,7 @@ $.extend(Timepicker.prototype, {
 			var dp_dateFormat = $.datepicker._get(this.inst, 'dateFormat');
 			// escape special regex characters in the seperator
 			var specials = new RegExp("[.*+?|()\\[\\]{}\\\\]", "g");
-			regstr = '.{' + dp_dateFormat.length + ',}' + this._defaults.separator.replace(specials, "\\$&") + regstr;
+			regstr = '^.{' + dp_dateFormat.length + ',}?' + this._defaults.separator.replace(specials, "\\$&") + regstr;
 		}
 		
 		treg = timeString.match(new RegExp(regstr, 'i'));


### PR DESCRIPTION
https://github.com/trentrichardson/jQuery-Timepicker-Addon/issues/303
