### PR TITLE
Fix: Prevent "Uncaught RangeError: Maximum call stack size exceeded"

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -20,6 +20,12 @@
 
 (function($) {
 
+// Prevent "Uncaught RangeError: Maximum call stack size exceeded"
+$.ui.timepicker = $.ui.timepicker || {};
+if ($.ui.timepicker.version) {
+	return;
+}
+
 $.extend($.ui, { timepicker: { version: "0.9.9" } });
 
 /* Time picker manager.


### PR DESCRIPTION
I made this pull request including code from this: http://trentrichardson.com/2011/07/29/many-updates-to-timepicker/#comment-32649
