### PR TITLE
Update timezone even when showTimezone is false

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1420,7 +1420,7 @@ var parseDateTimeInternal = function(dateFormat, timeFormat, dateTimeString, dat
 //#######################################################################################
 var selectLocalTimeZone = function(tp_inst, date)
 {
-	if (tp_inst && tp_inst._defaults.showTimezone && tp_inst.timezone_select) {
+	if (tp_inst && tp_inst.timezone_select) {
 		tp_inst.useLocalTimezone = true;
 		var now = typeof date !== 'undefined' ? date : new Date();
 		var tzoffset = now.getTimezoneOffset(); // If +0100, returns -60


### PR DESCRIPTION
I want user's timezone to be displayed and changed automatically, but not letting them change it,
so i use these parameters :

```
{
    timeFormat:'hh:mm z',
    useLocalTimezone:true
    showTimezone:false
}
```

This patch allows the displayed timezone to be updated even when the "timezone select" is hidden.
