### PR TITLE
Remove input ID references for dynamic manipulation

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1,14 +1,14 @@
 /*
 * jQuery timepicker addon
 * By: Trent Richardson [http://trentrichardson.com]
-* Version 1.0.0
+* Version 0.9.9
 * Last Modified: 02/05/2012
-*
+* 
 * Copyright 2012 Trent Richardson
 * Dual licensed under the MIT and GPL licenses.
 * http://trentrichardson.com/Impromptu/GPL-LICENSE.txt
 * http://trentrichardson.com/Impromptu/MIT-LICENSE.txt
-*
+* 
 * HERES THE CSS:
 * .ui-timepicker-div .ui-widget-header { margin-bottom: 8px; }
 * .ui-timepicker-div dl { text-align: left; }
@@ -20,13 +20,7 @@
 
 (function($) {
 
-// Prevent "Uncaught RangeError: Maximum call stack size exceeded"
-$.ui.timepicker = $.ui.timepicker || {};
-if ($.ui.timepicker.version) {
-	return;
-}
-
-$.extend($.ui, { timepicker: { version: "1.0.0" } });
+$.extend($.ui, { timepicker: { version: "0.9.9" } });
 
 /* Time picker manager.
    Use the singleton instance of this class, $.timepicker, to interact with the time picker.
@@ -139,7 +133,7 @@ $.extend(Timepicker.prototype, {
 	_newInst: function($input, o) {
 		var tp_inst = new Timepicker(),
 			inlineSettings = {};
-
+			
 		for (var attrName in this._defaults) {
 			var attrValue = $input.attr('time:' + attrName);
 			if (attrValue) {
@@ -169,8 +163,8 @@ $.extend(Timepicker.prototype, {
 			},
 			timepicker: tp_inst // add timepicker as a property of datepicker: $.datepicker._get(dp_inst, 'timepicker');
 		});
-		tp_inst.amNames = $.map(tp_inst._defaults.amNames, function(val) { return val.toUpperCase(); });
-		tp_inst.pmNames = $.map(tp_inst._defaults.pmNames, function(val) { return val.toUpperCase(); });
+		tp_inst.amNames = $.map(tp_inst._defaults.amNames, function(val) { return val.toUpperCase() });
+		tp_inst.pmNames = $.map(tp_inst._defaults.pmNames, function(val) { return val.toUpperCase() });
 
 		if (tp_inst._defaults.timezoneList === null) {
 			var timezoneList = [];
@@ -194,7 +188,7 @@ $.extend(Timepicker.prototype, {
 			tp_inst.$altInput = $(o.altField)
 				.css({ cursor: 'pointer' })
 				.focus(function(){ $input.trigger("focus"); });
-
+		
 		if(tp_inst._defaults.minDate==0 || tp_inst._defaults.minDateTime==0)
 		{
 			tp_inst._defaults.minDate=new Date();
@@ -203,7 +197,7 @@ $.extend(Timepicker.prototype, {
 		{
 			tp_inst._defaults.maxDate=new Date();
 		}
-
+		
 		// datepicker needs minDate/maxDate, timepicker needs minDateTime/maxDateTime..
 		if(tp_inst._defaults.minDate !== undefined && tp_inst._defaults.minDate instanceof Date)
 			tp_inst._defaults.minDateTime = new Date(tp_inst._defaults.minDate.getTime());
@@ -221,7 +215,7 @@ $.extend(Timepicker.prototype, {
 	//########################################################################
 	_addTimePicker: function(dp_inst) {
 		var currDT = (this.$altInput && this._defaults.altFieldTimeOnly) ?
-				this.$input.val() + ' ' + this.$altInput.val() :
+				this.$input.val() + ' ' + this.$altInput.val() : 
 				this.$input.val();
 
 		this.timeDefined = this._parseTime(currDT);
@@ -255,7 +249,7 @@ $.extend(Timepicker.prototype, {
 			var specials = new RegExp("[.*+?|()\\[\\]{}\\\\]", "g");
 			regstr = '^.{' + dp_dateFormat.length + ',}?' + this._defaults.separator.replace(specials, "\\$&") + regstr;
 		}
-
+		
 		treg = timeString.match(new RegExp(regstr, 'i'));
 
 		if (treg) {
@@ -303,7 +297,7 @@ $.extend(Timepicker.prototype, {
 				}
 				this.timezone = tz;
 			}
-
+			
 			return true;
 
 		}
@@ -314,13 +308,13 @@ $.extend(Timepicker.prototype, {
 	// pattern for standard and localized AM/PM markers
 	//########################################################################
 	_getPatternAmpm: function() {
-		var markers = [],
+		var markers = [];
 			o = this._defaults;
 		if (o.amNames)
 			$.merge(markers, o.amNames);
 		if (o.pmNames)
 			$.merge(markers, o.pmNames);
-		markers = $.map(markers, function(val) { return val.replace(/[.*+?|()\[\]{}\\]/g, '\\$&'); });
+		markers = $.map(markers, function(val) { return val.replace(/[.*+?|()\[\]{}\\]/g, '\\$&') });
 		return '(' + markers.join('|') + ')?';
 	},
 
@@ -352,28 +346,27 @@ $.extend(Timepicker.prototype, {
 			hourMax = parseInt((o.hourMax - ((o.hourMax - o.hourMin) % o.stepHour)) ,10),
 			minMax  = parseInt((o.minuteMax - ((o.minuteMax - o.minuteMin) % o.stepMinute)) ,10),
 			secMax  = parseInt((o.secondMax - ((o.secondMax - o.secondMin) % o.stepSecond)) ,10),
-			millisecMax  = parseInt((o.millisecMax - ((o.millisecMax - o.millisecMin) % o.stepMillisec)) ,10),
-			dp_id = this.inst.id.toString().replace(/([^A-Za-z0-9_])/g, '');
+			millisecMax  = parseInt((o.millisecMax - ((o.millisecMax - o.millisecMin) % o.stepMillisec)) ,10);
 
 		// Prevent displaying twice
 		//if ($dp.find("div#ui-timepicker-div-"+ dp_id).length === 0) {
-		if ($dp.find("div#ui-timepicker-div-"+ dp_id).length === 0 && o.showTimepicker) {
+		if ($dp.find("div.ui-timepicker-div").length === 0 && o.showTimepicker) {
 			var noDisplay = ' style="display:none;"',
-				html =	'<div class="ui-timepicker-div" id="ui-timepicker-div-' + dp_id + '"><dl>' +
-						'<dt class="ui_tpicker_time_label" id="ui_tpicker_time_label_' + dp_id + '"' +
+				html =	'<div class="ui-timepicker-div"><dl>' +
+						'<dt class="ui_tpicker_time_label"' +
 						((o.showTime) ? '' : noDisplay) + '>' + o.timeText + '</dt>' +
-						'<dd class="ui_tpicker_time" id="ui_tpicker_time_' + dp_id + '"' +
+						'<dd class="ui_tpicker_time"' +
 						((o.showTime) ? '' : noDisplay) + '></dd>' +
-						'<dt class="ui_tpicker_hour_label" id="ui_tpicker_hour_label_' + dp_id + '"' +
+						'<dt class="ui_tpicker_hour_label"' +
 						((o.showHour) ? '' : noDisplay) + '>' + o.hourText + '</dt>',
 				hourGridSize = 0,
 				minuteGridSize = 0,
 				secondGridSize = 0,
 				millisecGridSize = 0,
-				size = null;
+				size;
 
  			// Hours
-			html += '<dd class="ui_tpicker_hour"><div id="ui_tpicker_hour_' + dp_id + '"' +
+			html += '<dd class="ui_tpicker_hour"><div class="ui_tpicker_hour_hh"' +
 						((o.showHour) ? '' : noDisplay) + '></div>';
 			if (o.showHour && o.hourGrid > 0) {
 				html += '<div style="padding-left: 1px"><table class="ui-tpicker-grid-label"><tr>';
@@ -395,9 +388,9 @@ $.extend(Timepicker.prototype, {
 			html += '</dd>';
 
 			// Minutes
-			html += '<dt class="ui_tpicker_minute_label" id="ui_tpicker_minute_label_' + dp_id + '"' +
+			html += '<dt class="ui_tpicker_minute_label"' +
 					((o.showMinute) ? '' : noDisplay) + '>' + o.minuteText + '</dt>'+
-					'<dd class="ui_tpicker_minute"><div id="ui_tpicker_minute_' + dp_id + '"' +
+					'<dd class="ui_tpicker_minute"><div class="ui_tpicker_minute_mm"' +
 							((o.showMinute) ? '' : noDisplay) + '></div>';
 
 			if (o.showMinute && o.minuteGrid > 0) {
@@ -413,9 +406,9 @@ $.extend(Timepicker.prototype, {
 			html += '</dd>';
 
 			// Seconds
-			html += '<dt class="ui_tpicker_second_label" id="ui_tpicker_second_label_' + dp_id + '"' +
+			html += '<dt class="ui_tpicker_second_label"' +
 					((o.showSecond) ? '' : noDisplay) + '>' + o.secondText + '</dt>'+
-					'<dd class="ui_tpicker_second"><div id="ui_tpicker_second_' + dp_id + '"'+
+					'<dd class="ui_tpicker_second"><div class="ui_tpicker_second_ss"'+
 							((o.showSecond) ? '' : noDisplay) + '></div>';
 
 			if (o.showSecond && o.secondGrid > 0) {
@@ -431,9 +424,9 @@ $.extend(Timepicker.prototype, {
 			html += '</dd>';
 
 			// Milliseconds
-			html += '<dt class="ui_tpicker_millisec_label" id="ui_tpicker_millisec_label_' + dp_id + '"' +
+			html += '<dt class="ui_tpicker_millisec_label"' +
 					((o.showMillisec) ? '' : noDisplay) + '>' + o.millisecText + '</dt>'+
-					'<dd class="ui_tpicker_millisec"><div id="ui_tpicker_millisec_' + dp_id + '"'+
+					'<dd class="ui_tpicker_millisec"><div id="ui_tpicker_millisec_ms"'+
 							((o.showMillisec) ? '' : noDisplay) + '></div>';
 
 			if (o.showMillisec && o.millisecGrid > 0) {
@@ -449,9 +442,9 @@ $.extend(Timepicker.prototype, {
 			html += '</dd>';
 
 			// Timezone
-			html += '<dt class="ui_tpicker_timezone_label" id="ui_tpicker_timezone_label_' + dp_id + '"' +
+			html += '<dt class="ui_tpicker_timezone_label"' +
 					((o.showTimezone) ? '' : noDisplay) + '>' + o.timezoneText + '</dt>';
-			html += '<dd class="ui_tpicker_timezone" id="ui_tpicker_timezone_' + dp_id + '"'	+
+			html += '<dd class="ui_tpicker_timezone_tz"'	+
 							((o.showTimezone) ? '' : noDisplay) + '></dd>';
 
 			html += '</dl></div>';
@@ -466,7 +459,7 @@ $.extend(Timepicker.prototype, {
 				$dp.find('.ui-datepicker-header, .ui-datepicker-calendar').hide();
 			}
 
-			this.hour_slider = $tp.find('#ui_tpicker_hour_'+ dp_id).slider({
+			this.hour_slider = $tp.find('.ui_tpicker_hour_hh').slider({
 				orientation: "horizontal",
 				value: this.hour,
 				min: o.hourMin,
@@ -478,10 +471,10 @@ $.extend(Timepicker.prototype, {
 				}
 			});
 
-
+			
 			// Updated by Peter Medeiros:
 			// - Pass in Event and UI instance into slide function
-			this.minute_slider = $tp.find('#ui_tpicker_minute_'+ dp_id).slider({
+			this.minute_slider = $tp.find('.ui_tpicker_minute_mm').slider({
 				orientation: "horizontal",
 				value: this.minute,
 				min: o.minuteMin,
@@ -493,7 +486,7 @@ $.extend(Timepicker.prototype, {
 				}
 			});
 
-			this.second_slider = $tp.find('#ui_tpicker_second_'+ dp_id).slider({
+			this.second_slider = $tp.find('.ui_tpicker_second_ss').slider({
 				orientation: "horizontal",
 				value: this.second,
 				min: o.secondMin,
@@ -505,7 +498,7 @@ $.extend(Timepicker.prototype, {
 				}
 			});
 
-			this.millisec_slider = $tp.find('#ui_tpicker_millisec_'+ dp_id).slider({
+			this.millisec_slider = $tp.find('.ui_tpicker_millisec_ms').slider({
 				orientation: "horizontal",
 				value: this.millisec,
 				min: o.millisecMin,
@@ -517,7 +510,7 @@ $.extend(Timepicker.prototype, {
 				}
 			});
 
-			this.timezone_select = $tp.find('#ui_tpicker_timezone_'+ dp_id).append('<select></select>').find("select");
+			this.timezone_select = $tp.find('.ui_tpicker_timezone_tz').append('<select></select>').find("select");
 			$.fn.append.apply(this.timezone_select,
 				$.map(o.timezoneList, function(val, idx) {
 					return $("<option />")
@@ -624,7 +617,7 @@ $.extend(Timepicker.prototype, {
 			if ($buttonPanel.length) $buttonPanel.before($tp);
 			else $dp.append($tp);
 
-			this.$timeObj = $tp.find('#ui_tpicker_time_'+ dp_id);
+			this.$timeObj = $tp.find('.ui_tpicker_time');
 
 			if (this.inst !== null) {
 				var timeDefined = this.timeDefined;
@@ -640,7 +633,7 @@ $.extend(Timepicker.prototype, {
 			this.minute_slider.bind('slidestop',onSelectDelegate);
 			this.second_slider.bind('slidestop',onSelectDelegate);
 			this.millisec_slider.bind('slidestop',onSelectDelegate);
-
+			
 			// slideAccess integration: http://trentrichardson.com/2011/11/11/jquery-ui-sliders-and-touch-accessibility/
 			if (this._defaults.addSliderAccess){
 				var sliderAccessArgs = this._defaults.sliderAccessArgs;
@@ -657,7 +650,7 @@ $.extend(Timepicker.prototype, {
 									oldMarginLeft = $g.css('marginLeft').toString().replace('%',''),
 									newWidth = oldWidth - sliderAccessWidth,
 									newMarginLeft = ((oldMarginLeft * newWidth)/oldWidth) + '%';
-
+						
 								$g.css({ width: newWidth, marginLeft: newMarginLeft });
 							});
 						}
@@ -665,7 +658,7 @@ $.extend(Timepicker.prototype, {
 				},0);
 			}
 			// end slideAccess integration
-
+			
 		}
 	},
 
@@ -776,7 +769,7 @@ $.extend(Timepicker.prototype, {
 
 	},
 
-
+	
 	//########################################################################
 	// when a slider moves, set the internal time...
 	// on time change is also called when the time is updated in the text field
@@ -809,7 +802,7 @@ $.extend(Timepicker.prototype, {
 				|| (this.ampm.length > 0
 				    && (hour < 12) != ($.inArray(this.ampm.toUpperCase(), this.amNames) !== -1))
 				|| timezone != this.timezone);
-
+		
 		if (hasChanged) {
 
 			if (hour !== false)this.hour = hour;
@@ -817,22 +810,22 @@ $.extend(Timepicker.prototype, {
 			if (second !== false) this.second = second;
 			if (millisec !== false) this.millisec = millisec;
 			if (timezone !== false) this.timezone = timezone;
-
+			
 			if (!this.inst) this.inst = $.datepicker._getInst(this.$input[0]);
-
+			
 			this._limitMinMaxDateTime(this.inst, true);
 		}
 		if (o.ampm) this.ampm = ampm;
-
+		
 		//this._formatTime();
 		this.formattedTime = $.datepicker.formatTime(this._defaults.timeFormat, this, this._defaults);
 		if (this.$timeObj) this.$timeObj.text(this.formattedTime + o.timeSuffix);
 		this.timeDefined = true;
 		if (hasChanged) this._updateDateTime();
 	},
-
+    
 	//########################################################################
-	// call custom onSelect.
+	// call custom onSelect. 
 	// bind to sliders slidestop, and grid click.
 	//########################################################################
 	_onSelectHandler: function() {
@@ -851,7 +844,7 @@ $.extend(Timepicker.prototype, {
 		var tmptime = (format || this._defaults.timeFormat).toString();
 
 		tmptime = $.datepicker.formatTime(tmptime, time, this._defaults);
-
+		
 		if (arguments.length) return tmptime;
 		else this.formattedTime = tmptime;
 	},
@@ -889,7 +882,7 @@ $.extend(Timepicker.prototype, {
 		} else {
 			this.$input.val(formattedDateTime);
 		}
-
+		
 		this.$input.trigger("change");
 	}
 
@@ -915,12 +908,13 @@ $.fn.extend({
 	//########################################################################
 	datetimepicker: function(o) {
 		o = o || {};
+		var $input = this,
 		tmp_args = arguments;
 
 		if (typeof(o) == 'string'){
-			if(o == 'getDate')
+			if(o == 'getDate') 
 				return $.fn.datepicker.apply($(this[0]), tmp_args);
-			else
+			else 
 				return this.each(function() {
 					var $t = $(this);
 					$t.datepicker.apply($t, tmp_args);
@@ -935,7 +929,7 @@ $.fn.extend({
 });
 
 //########################################################################
-// format the time all pretty...
+// format the time all pretty... 
 // format = string format of the time
 // time = a {}, not a Date() for timezones
 // options = essentially the regional[].. amNames, pmNames, ampm
@@ -944,7 +938,7 @@ $.datepicker.formatTime = function(format, time, options) {
 	options = options || {};
 	options = $.extend($.timepicker._defaults, options);
 	time = $.extend({hour:0, minute:0, second:0, millisec:0, timezone:'+0000'}, time);
-
+	
 	var tmptime = format;
 	var ampmName = options['amNames'][0];
 
@@ -980,7 +974,7 @@ $.datepicker.formatTime = function(format, time, options) {
 
 	tmptime = $.trim(tmptime);
 	return tmptime;
-};
+}
 
 //########################################################################
 // the bad hack :/ override datepicker so it doesnt close on select
@@ -1020,9 +1014,9 @@ $.datepicker._updateDatepicker = function(inst) {
 	}
 
 	if (typeof(inst.stay_open) !== 'boolean' || inst.stay_open === false) {
-
+				
 		this._base_updateDatepicker(inst);
-
+		
 		// Reload the time control when changing something in the input text field.
 		var tp_inst = this._get(inst, 'timepicker');
 		if(tp_inst) tp_inst._addTimePicker(inst);
@@ -1060,7 +1054,7 @@ $.datepicker._doKeyPress = function(event) {
 			return event.ctrlKey || (chr < ' ' || !dateChars || datetimeChars.indexOf(chr) > -1);
 		}
 	}
-
+	
 	return $.datepicker._base_doKeyPress(event);
 };
 
@@ -1107,7 +1101,7 @@ $.datepicker._gotoToday = function(id) {
 		tp_inst.timezone_select.val(tzoffset);
 	}
 	this._setTime(inst, now);
-	$( '.ui-datepicker-today', $dp).click();
+	$( '.ui-datepicker-today', $dp).click(); 
 };
 
 //#######################################################################################
@@ -1250,11 +1244,14 @@ $.datepicker.parseDate = function(format, value, settings) {
 //#######################################################################################
 // override formatDate to set date with time to the input
 //#######################################################################################
-$.datepicker._base_formatDate = $.datepicker._formatDate;
+$.datepicker._base_formatDate=$.datepicker._formatDate;
 $.datepicker._formatDate = function(inst, day, month, year){
 	var tp_inst = this._get(inst, 'timepicker');
-	if(tp_inst) {
-		tp_inst._updateDateTime(inst);
+	if(tp_inst)
+	{
+		if(day)
+			var b = this._base_formatDate(inst, day, month, year);
+		tp_inst._updateDateTime(inst);	
 		return tp_inst.$input.val();
 	}
 	return this._base_formatDate(inst);
@@ -1268,16 +1265,16 @@ $.datepicker._optionDatepicker = function(target, name, value) {
 	var inst = this._getInst(target),
 		tp_inst = this._get(inst, 'timepicker');
 	if (tp_inst) {
-		var min = null, max = null, onselect = null;
+		var min,max,onselect;
 		if (typeof name == 'string') { // if min/max was set with the string
-			if (name === 'minDate' || name === 'minDateTime' )
+			if (name==='minDate' || name==='minDateTime' )
 				min = value;
-			else if (name === 'maxDate' || name === 'maxDateTime')
+			else if (name==='maxDate' || name==='maxDateTime')
 				max = value;
-			else if (name === 'onSelect')
-				onselect = value;
+			else if (name==='onSelect')
+				onselect=value;
 		} else if (typeof name == 'object') { //if min/max was set with the JSON
-			if (name.minDate)
+			if(name.minDate)
 				min = name.minDate;
 			else if (name.minDateTime)
 				min = name.minDateTime;
@@ -1286,23 +1283,24 @@ $.datepicker._optionDatepicker = function(target, name, value) {
 			else if (name.maxDateTime)
 				max = name.maxDateTime;
 		}
-		if(min) { //if min was set
-			if (min == 0)
-				min = new Date();
+		if(min){ //if min was set
+			if(min==0)
+				min=new Date();
 			else
-				min = new Date(min);
-
+				min= new Date(min);
+			
 			tp_inst._defaults.minDate = min;
 			tp_inst._defaults.minDateTime = min;
-		} else if (max) { //if max was set
+		} else if (max){ //if max was set
 			if(max==0)
 				max=new Date();
 			else
 				max= new Date(max);
 			tp_inst._defaults.maxDate = max;
 			tp_inst._defaults.maxDateTime = max;
-		} else if (onselect)
-			tp_inst._defaults.onSelect = onselect;
+		}
+		else if (onselect)
+			tp_inst._defaults.onSelect=onselect;
 	}
 	if (value === undefined)
 		return this._base_optionDatepicker(target, name);
@@ -1321,6 +1319,7 @@ function extendRemove(target, props) {
 };
 
 $.timepicker = new Timepicker(); // singleton instance
-$.timepicker.version = "1.0.0";
+$.timepicker.version = "0.9.9";
 
 })(jQuery);
+


### PR DESCRIPTION
...still works, as beautifully! Needed to access the data objects set by the plugin for dynamic cloning of inputs. Wanted this to work in conjunction with my cloneya plugin that I plan to use in a wordpress plugin!
