### PR TITLE
Fix overwriting default options

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1032,7 +1032,7 @@ $.datepicker.parseTime = function(timeFormat, timeString, options) {
 //########################################################################
 $.datepicker.formatTime = function(format, time, options) {
 	options = options || {};
-	options = $.extend($.timepicker._defaults, options);
+	options = $.extend({}, $.timepicker._defaults, options);
 	time = $.extend({hour:0, minute:0, second:0, millisec:0, timezone:'+0000'}, time);
 
 	var tmptime = format;


### PR DESCRIPTION
Default options in singleton overwriting with options from first open calendar
