### PR TITLE
Added methods to enforce date range limits.

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -251,7 +251,7 @@ $.extend(Timepicker.prototype, {
 	_parseTime: function(timeString, withDate) {
 		if (!this.inst) {
 			this.inst = $.datepicker._getInst(this.$input[0]);
-        }
+		}
 		
 		if (withDate || !this._defaults.timeOnly) 
 		{
@@ -1534,5 +1534,110 @@ var timeZoneString = function(date)
 
 $.timepicker = new Timepicker(); // singleton instance
 $.timepicker.version = "1.0.2";
+
+/**
+ * Calls `timepicker()` on the `startTime` and `endTime` elements, and configures them to
+ * enforce date range limits.
+ * n.b. The input value must be correctly formatted (reformatting is not supported)
+ * @param  Element startTime
+ * @param  Element endTime
+ * @param  obj options Options for the timepicker() call
+ * @return jQuery
+ */
+$.timepicker.timeRange = function( startTime, endTime, options ) {
+	return $.timepicker.handleRange('timepicker', startTime, endTime, options);
+}
+
+/**
+ * Calls `datetimepicker` on the `startTime` and `endTime` elements, and configures them to
+ * enforce date range limits.
+ * @param  Element startTime
+ * @param  Element endTime
+ * @param  obj options Options for the `timepicker()` call. Also supports `reformat`,
+ *   a boolean value that can be used to reformat the input values to the `dateFormat`.
+ * @param  string method Can be used to specify the type of picker to be added
+ * @return jQuery
+ */
+$.timepicker.dateTimeRange = function( startTime, endTime, options ) {
+	$.timepicker.dateRange(startTime, endTime, options, 'datetimepicker');
+}
+
+/**
+ * Calls `method` on the `startTime` and `endTime` elements, and configures them to
+ * enforce date range limits.
+ * @param  Element startTime
+ * @param  Element endTime
+ * @param  obj options Options for the `timepicker()` call. Also supports `reformat`,
+ *   a boolean value that can be used to reformat the input values to the `dateFormat`.
+ * @param  string method Can be used to specify the type of picker to be added
+ * @return jQuery
+ */
+$.timepicker.dateRange = function( startTime, endTime, options, method ) {
+	method = method || 'datepicker';
+	$.timepicker.handleRange(method, startTime, endTime, options);
+}
+
+/**
+ * Calls `method` on the `startTime` and `endTime` elements, and configures them to
+ * enforce date range limits.
+ * @param  string method Can be used to specify the type of picker to be added
+ * @param  Element startTime
+ * @param  Element endTime
+ * @param  obj options Options for the `timepicker()` call. Also supports `reformat`,
+ *   a boolean value that can be used to reformat the input values to the `dateFormat`.
+ * @return jQuery
+ */
+$.timepicker.handleRange = function( method, startTime, endTime, options ) {
+	$.fn[method].call(startTime, $.extend({}, {
+			onClose: function(dateText, inst) {
+				checkDates(this, endTime, dateText);
+			},
+			onSelect: function (selectedDateTime) {
+				selected(this, endTime, 'minDate');
+			}
+		}, options)
+	);
+	$.fn[method].call(endTime, $.extend({}, {
+			onClose: function(dateText, inst) {
+				checkDates(this, startTime, dateText);
+			},
+			onSelect: function (selectedDateTime) {
+				selected(this, startTime, 'maxDate');
+			}
+		}, options)
+	);
+	// timepicker doesn't provide access to its 'timeFormat' option, 
+	// nor could I get datepicker.formatTime() to behave with times, so I
+	// have disabled reformatting for timepicker
+	if( method != 'timepicker' && options.reformat ) {
+		$([startTime, endTime]).each(function() {
+			var format = $(this)[method].call($(this), 'option', 'dateFormat'),
+				date = new Date($(this).val());
+			if( $(this).val() && date ) {
+				$(this).val($.datepicker.formatDate(format, date));
+			}
+		});
+	}
+	checkDates(startTime, endTime, startTime.val());
+	function checkDates(changed, other, dateText) {
+		if( other.val() && (new Date(startTime.val()) > new Date(endTime.val())) ) {
+			other.val(dateText);
+		}
+	}
+	selected(startTime, endTime, 'minDate');
+	selected(endTime, startTime, 'maxDate');
+	function selected(changed, other, option) {
+		if( !$(changed).val() ) {
+			return;
+		}
+		var date = $(changed)[method].call($(changed), 'getDate');
+		// timepicker doesn't implement 'getDate' and returns a jQuery
+		if( date.getTime ) {
+			$(other)[method].call($(other), 'option', option, date);
+		}
+	}
+	return $([startTime.get(0), endTime.get(0)]);
+};
+
 
 })(jQuery);


### PR DESCRIPTION
I also added a `reformat` option to the methods. This reformats whatever is in the `<input>`  value to be formatted using the `dateFormat`. However I could find a way to get access to `timepicker`'s `timeFormat` option, nor could I get `$.datepicker.formatTime()` to behave with "09:00 am", so I have disabled this reformatting option when adding a `timepicker`.

Cheers,

Simon
