### PR TITLE
Fixes #335

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -280,7 +280,7 @@ $.extend(Timepicker.prototype, {
 	//########################################################################
 	_injectTimePicker: function() {
 		var $dp = this.inst.dpDiv,
-			o = this._defaults,
+			o = this.inst.settings,
 			tp_inst = this,
 			// Added by Peter Medeiros:
 			// - Figure out what the hour/minute/second max should be based on the step values.


### PR DESCRIPTION
_injectTimePicker HTML was getting data only from the default or initially provided value.

Changed one line to accept the settings that have been extended at the datepicker level.
