### PR TITLE
Fix splitDateTime function to work with IE7

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1571,7 +1571,7 @@
 			if (allPartsLen > 0) {
 				return [
 						allParts.splice(0,allPartsLen-timePartsLen).join(separator),
-						allParts.splice(timePartsLen*-1).join(separator)
+						allParts.splice(0,timePartsLen).join(separator)
 					];
 			}
 


### PR DESCRIPTION
The syntax for the second part of the splice does not work in IE7 (possibly others I haven't checked).  Have changed to a zero start index without reversing the sign of the timePartsLen.  As splice removes elements from the array, this way makes more logical sense anyway.  Works in IE7, IE9 and chrome 21.0. 
