### PR TITLE
fix splitDateTime for plain datepicker

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1425,8 +1425,16 @@
 	*/
 	$.datepicker._base_parseDate = $.datepicker.parseDate;
 	$.datepicker.parseDate = function(format, value, settings) {
-		var splitRes = splitDateTime(format, value, settings);
-		return $.datepicker._base_parseDate(format, splitRes[0], settings);
+		var date;
+		try {
+			date = this._base_parseDate(format, value, settings);
+		} catch (err) {
+			// Hack!  The error message ends with a colon, a space, and
+			// the "extra" characters.  We rely on that instead of
+			// attempting to perfectly reproduce the parsing algorithm.
+			date = this._base_parseDate(format, value.substring(0,value.length-(err.length-err.indexOf(':')-2)), settings);
+		}
+		return date;
 	};
 
 	/*


### PR DESCRIPTION
Pull request for dev this time, instead of master.

When using a plain datepicker, getDate returns always the current date because splitDateTime puts the date in the time part of the result.
This change only splits when the input actually contains a time.
