### PR TITLE
staticTimezone - Dev

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1349,7 +1349,7 @@
 	/*
 	* Format the given date/time for a different timezone.
 	*/
-	$.datepicker._formatDateForTimezone(dateToFormat, offset) {
+	$.datepicker._formatDateForTimezone = function(dateToFormat, offset) {
 		var nowLocal = dateToFormat;
 		//convert the +0000 formated offset into hours
 		var offsetInt = parseInt(offset, 10) / 100;
@@ -1400,7 +1400,7 @@
 		if (tp_inst) {
 			var defaults = tp_inst._defaults;
 			
-			//format the date for a the staticTimezone if neccessary
+			//format the date for the staticTimezone if neccessary
 			if(defaults.useStaticTimezone == true) {
 				date = $.datepicker._formatDateForTimezone(date, defaults.staticTimezone);
 			}


### PR DESCRIPTION
I added the ability to specify a static timezone. When enabled (`useStaticTimezone: true`), all dates that go through `_setTime()` will be formatted for the specified timezone (`staticTimezone: "+0000"`). This will allow a user to select a time in their local, but then the plugin will automatically change it to the server's local (or any other timezone for that matter). This is especially useful with the "Now" button. I wrote this to suit my needs, and I thought that perhaps someone else would come down the road needing the same functionality. If there's something wrong with it, or my code isn't structured as you would have it, just let me know. Any feedback is appreciated, thanks.
