### PR TITLE
jquery-ui-sliderAccess call slider "stop" when changing time with buttons

### DIFF
--- a/jquery-ui-sliderAccess.js
+++ b/jquery-ui-sliderAccess.js
@@ -60,6 +60,8 @@
 											$t.slider('value', newval);
 
 											$t.slider("option", "slide").call($t, null, { value: newval });
+											$t.slider("option", "stop").call($t, null, { value: newval });
+
 										});
 						});
 						


### PR DESCRIPTION
I added a call to jquery-ui-sliderAccess so that slider "stop" is called and bound functions (onSelect) are called in datetimepicker.  I was having problems with datepicker onSelect event not happening when using the +/- buttons on timepicker.
