### PR TITLE
12 hour format, force alt field to always be UTC

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1130,6 +1130,26 @@
 		return false;
 	};
 
+	_convert24to12 = function(hour) {
+		if (hour > 12) {
+			hour = hour - 12;
+		}
+
+		if (hour == 0) {
+			hour = 12;
+		}
+
+		var result;
+		if (hour < 10) {
+			result = "0" + hour;
+		}
+		else {
+			result = String(hour);
+		}
+
+		return result;
+	};
+
 	/*
 	* Public utility to format the time
 	* format = string format of the time
@@ -1154,16 +1174,14 @@
 		if (options.ampm) {
 			if (hour > 11) {
 				ampmName = options.pmNames[0];
-				if (hour > 12) {
-					hour = hour % 12;
-				}
-			}
-			if (hour === 0) {
-				hour = 12;
 			}
 		}
-		tmptime = tmptime.replace(/(?:hh?|mm?|ss?|[tT]{1,2}|[lz]|'.*?')/g, function(match) {
-			switch (match.toLowerCase()) {
+		tmptime = tmptime.replace(/(?:HH?|hh?|mm?|ss?|[tT]{1,2}|[lz]|('.*?'|".*?"))/g, function(match) {
+		switch (match) {
+			case 'HH':
+				return _convert24to12(hour).slice(-2);
+			case 'H':
+				return _convert24to12(hour);
 			case 'hh':
 				return ('0' + hour).slice(-2);
 			case 'h':


### PR DESCRIPTION
Here is one fix and one feature
## 12 hour formatting option

The fix addresses issue(s) #459 and #479

to use the fix simply use a capital "H" instead of a lower case "h" in your time format specifier to force usage of 12 hour time format, "HH" with leading zero and "H" without, for example. The `ampm` option now only affects the process of time picking and not the resulting output. This will, for example, display times in 12 hour format, but the time picker should remain in 24 hour format

```
$("foo").datetimepicker({
      "timeFormat": "H:mm",
      "altTimeFormat": "HH:mm:ss"
});
```

not that you'd want this ever, but the feature works the other way as well - so of course, you can still use lower case "h" to get a nice display format on the frontend and a more easily parsable format for the backend

```
$("foo").datetimepicker({
      "timeFormat": "H:mm",
      "altTimeFormat": "hh:mm:ss"
});
```

working demo: http://jsfiddle.net/SyNCp/1/
