### PR TITLE
date range and alternate fields

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1320,9 +1320,9 @@
 					altTimeFormat = tp_inst._defaults.altTimeFormat !== null ? tp_inst._defaults.altTimeFormat : tp_inst._defaults.timeFormat;
 				
 				altFormattedDateTime += $.datepicker.formatTime(altTimeFormat, tp_inst, tp_inst._defaults) + altTimeSuffix;
-				if(!tp_inst._defaults.timeOnly && !tp_inst._defaults.altFieldTimeOnly){
+				if(!tp_inst._defaults.timeOnly && !tp_inst._defaults.altFieldTimeOnly && date != null){
 					if(tp_inst._defaults.altFormat)
-						altFormattedDateTime = $.datepicker.formatDate(tp_inst._defaults.altFormat, (date === null ? new Date() : date), formatCfg) + altSeparator + altFormattedDateTime;
+						altFormattedDateTime = $.datepicker.formatDate(tp_inst._defaults.altFormat, date, formatCfg) + altSeparator + altFormattedDateTime;
 					else altFormattedDateTime = tp_inst.formattedDate + altSeparator + altFormattedDateTime;
 				}
 				$(altField).val(altFormattedDateTime);


### PR DESCRIPTION
if we use construction like this

``` html
<input type="text" id="from" name="from" />
<input type="text" id="altfrom" name="altfrom" />
<input type="text" id="to" name="to" />
<input type="text" id="altto" name="altto" />
```

``` javascript
$(function() {
  $( "#from" ).datetimepicker({
    onClose: function( selectedDate ) {
      altField: "#altfrom",
      altFieldTimeOnly: false,
      $( "#to" ).datetimepicker( "option", "minDate", selectedDate );
    }
  });
  $( "#to" ).datetimepicker({
    onClose: function( selectedDate ) {
      altField: "#altto",
      altFieldTimeOnly: false,
      $( "#from" ).datetimepicker( "option", "maxDate", selectedDate );
    }
  });
});
```

when we select datetime on first field **#from** it's populate **#altto** field with current date
