### PR TITLE
Update jquery-ui-timepicker-pt-BR.js (correcting portuguese)

### DIFF
--- a/localization/jquery-ui-timepicker-pt-BR.js
+++ b/localization/jquery-ui-timepicker-pt-BR.js
@@ -2,7 +2,7 @@
 /* Written by Diogo Damiani (diogodamiani@gmail.com) */
 (function ($) {
 	$.timepicker.regional['pt-BR'] = {
-		timeOnlyTitle: 'Escolha a horário',
+		timeOnlyTitle: 'Escolha o horário',
 		timeText: 'Horário',
 		hourText: 'Hora',
 		minuteText: 'Minutos',


### PR DESCRIPTION
Just a typo: "a" is not the correct preposition for "horário" in pt-BR
It should be "o horário"
