### PR TITLE
Fix defaultDate option of DatePicker when including TimePicker

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1535,11 +1535,15 @@
 		try {
 			date = this._base_parseDate(format, value, settings);
 		} catch (err) {
-			// Hack!  The error message ends with a colon, a space, and
-			// the "extra" characters.  We rely on that instead of
-			// attempting to perfectly reproduce the parsing algorithm.
-			date = this._base_parseDate(format, value.substring(0,value.length-(err.length-err.indexOf(':')-2)), settings);
-			$.timepicker.log("Error parsing the date string: " + err + "\ndate string = " + value + "\ndate format = " + format);
+			if (err.indexOf(":") >= 0) {
+				// Hack!  The error message ends with a colon, a space, and
+				// the "extra" characters.  We rely on that instead of
+				// attempting to perfectly reproduce the parsing algorithm.
+				date = this._base_parseDate(format, value.substring(0,value.length-(err.length-err.indexOf(':')-2)), settings);
+				$.timepicker.log("Error parsing the date string: " + err + "\ndate string = " + value + "\ndate format = " + format);
+			} else {
+				throw err;
+			}
 		}
 		return date;
 	};


### PR DESCRIPTION
Just including TimePicker breaks DatePickers defaultDate option, as it swallows all exceptions generated by $.datepicker.parseDate.

DatePicker relies on certain exceptions being thrown by that method, though. This fix double-checks, and only swallows exceptions which are actually handled by the additional code in TimePicker's defaultDate function.

This fixes #546 and probably #270, too
