### PR TITLE
correct timeText and units in swedish translation

### DIFF
--- a/i18n/jquery-ui-timepicker-sv.js
+++ b/i18n/jquery-ui-timepicker-sv.js
@@ -3,12 +3,12 @@
 (function($) {
 	$.timepicker.regional['sv'] = {
 		timeOnlyTitle: 'Välj en tid',
-		timeText: 'Timme',
-		hourText: 'Timmar',
-		minuteText: 'Minuter',
-		secondText: 'Sekunder',
-		millisecText: 'Millisekunder',
-		microsecText: 'Mikrosekunder',
+		timeText: 'Tid',
+		hourText: 'Timme',
+		minuteText: 'Minut',
+		secondText: 'Sekund',
+		millisecText: 'Millisekund',
+		microsecText: 'Mikrosekund',
 		timezoneText: 'Tidszon',
 		currentText: 'Nu',
 		closeText: 'Stäng',


### PR DESCRIPTION
Thanks for your great timepicker. I noticed the swedish translation was incorrect and fixed it for my own project, thought you might want to include the correct translation in your project. I fixed the timeText which read "Hour". I also changed all the time units to singular form as you have in english. Plural would make sense when picking a duration but I suspect the main use case for this addon is picking a time.

Regards,
Zoee
