### PR TITLE
call limitMinMax when a control gets created

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -543,6 +543,7 @@
 				}
 				// end slideAccess integration
 
+				tp_inst._limitMinMaxDateTime(this.inst, true);
 			}
 		},
 


### PR DESCRIPTION
If you specified minDateTime the sliders wouldn't be updated with
correct min/max values until you modified the date. This call make sure
we updates the sliders min/max values at creation too
