### PR TITLE
Added missing time format parameter in detectSupport call.

### DIFF
--- a/jquery-ui-timepicker-addon.js
+++ b/jquery-ui-timepicker-addon.js
@@ -1804,7 +1804,7 @@
 				millisec: isIn(tf,'l'),
 				microsec: isIn(tf,'c'),
 				timezone: isIn(tf,'z'),
-				ampm: isIn('t') && isIn(timeFormat,'h'),
+				ampm: isIn(tf,'t') && isIn(timeFormat,'h'),
 				iso8601: isIn(timeFormat, 'Z')
 			};
 	};


### PR DESCRIPTION
In detectSupport(), the call to set ampm was missing a parameter.  The
code was been updated to include the time format string to the call for proper initialization.
