### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+  "name": "trentrichardson/jquery-timepicker-addon",
+  "description": "Adds a timepicker to jQueryUI Datepicker.",
+  "type": "component",
+  "homepage": "http://trentrichardson.com/examples/timepicker/",
+  "license": [
+    "MIT",
+    "GPL-2.0"
+  ],
+  "require": {
+    "robloach/component-installer": "*",
+    "components/jqueryui": "~1.10.2"
+  },
+  "extra": {
+    "component": {
+      "name": "jquery-timepicker-addon",
+      "scripts": [
+        "jquery-ui-sliderAccess.js",
+        "jquery-ui-timepicker-addon.js",
+        "i18n/**"
+      ],
+      "styles": [
+          "jquery-ui-timepicker-addon.css"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org) is a package manager for PHP. This allows jQuery-Timepicker-Addon to be downloaded by putting "trentrichardson/jquery-timepicker-addon" into your own composer.json file.

``` json
{
  "require": {
    "trentrichardson/jquery-timepicker-addon": "~1"
  }
}
```

Please update the jqueryui dependency like you update it in component.json.

_Notice that I had to set the jqueryui dependency to 1.10.2, because the versions before do not exist for Composer. So start updating the jqueryui dependency when you require jqueryui > 1.10.2_
