### PR TITLE
fix: Selecting a time should focus input field.

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -805,6 +805,7 @@
 			this.timeDefined = true;
 			if (hasChanged) {
 				this._updateDateTime();
+				this.$input.focus();
 			}
 		},
 


### PR DESCRIPTION
Upon selecting a time, the input should be focused (matching the JQuery date
picker logic), thus ensuring that the "on blur" event is triggered when the
calendar is closed (via the 'done' button or by clicking elsewhere on the
screen.)
