### PR TITLE
Fix failure when setting date as null

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -1611,7 +1611,7 @@
 		// object will only return the timezone offset for the current locale, so we 
 		// adjust it accordingly.  If not using timezone option this won't matter..
 		// If a timezone is different in tp, keep the timezone as is
-		if (tp_inst) {
+		if (tp_inst && tp_date) {
 			// look out for DST if tz wasn't specified
 			if (!tp_inst.support.timezone && tp_inst._defaults.timezone === null) {
 				tp_inst.timezone = tp_date.getTimezoneOffset() * -1;

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -7,6 +7,11 @@
 
     <link rel="shortcut icon" type="image/png" href="../lib/jasmine-1.3.1/jasmine_favicon.png">
     <link rel="stylesheet" type="text/css" href="../lib/jasmine-1.3.1/jasmine.css">
+    <style>
+        .ui-datepicker {
+            display: none;
+        }
+    </style>
     <script type="text/javascript" src="../lib/jasmine-1.3.1/jasmine.js"></script>
     <script type="text/javascript" src="../lib/jasmine-1.3.1/jasmine-html.js"></script>
     <script type="text/javascript" src="http://github.com/searls/jasmine-fixture/releases/1.0.5/1737/jasmine-fixture.js"></script>

--- a/test/jquery-ui-timepicker-addon_spec.js
+++ b/test/jquery-ui-timepicker-addon_spec.js
@@ -648,4 +648,17 @@ describe('datetimepicker', function() {
 			});
 		});
 	});
+
+	describe('methods', function() {
+		describe('setDate', function() {
+			it('should accept null as date', function() {
+				var $input = affix('input').datetimepicker();
+				$input.datetimepicker('setDate', '2013-11-25 15:30:25');
+
+				$input.datetimepicker('setDate', null);
+
+				expect($input.datetimepicker('getDate')).toBeNull();
+			});
+		});
+	});
 });


### PR DESCRIPTION
Otherwise, Timepicker is breaking Datepicker compatibility by not accepting null value.
