### PR TITLE
Fix typo in German translation

### DIFF
--- a/src/i18n/jquery-ui-timepicker-de.js
+++ b/src/i18n/jquery-ui-timepicker-de.js
@@ -2,7 +2,7 @@
 /* Written by Marvin */
 (function($) {
 	$.timepicker.regional['de'] = {
-		timeOnlyTitle: 'Zeit Wählen',
+		timeOnlyTitle: 'Zeit wählen',
 		timeText: 'Zeit',
 		hourText: 'Stunde',
 		minuteText: 'Minute',


### PR DESCRIPTION
As "wählen" is a verb it must start with a lower case letter.
