### PR TITLE
Issue # 687 - Calendar remians open after date selection when showTimepicker = false

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -1348,7 +1348,7 @@
 		var inst = this._getInst($(id)[0]),
 			tp_inst = this._get(inst, 'timepicker');
 
-		if (tp_inst) {
+		if (tp_inst && inst.settings.showTimepicker) {
 			tp_inst._limitMinMaxDateTime(inst, true);
 			inst.inline = inst.stay_open = true;
 			//This way the onSelect handler called from calendarpicker get the full dateTime


### PR DESCRIPTION
There's an override to the _selectDate() method that prevents the calendar from closing after selecting a new date. If the timepicker is not enabled then there's no reason to execute this code, it should instead fire the base _selectDate() method since the jQuery Datepicker is designed to close upon selection.
