### PR TITLE
Fix typos in Basque translation

### DIFF
--- a/src/i18n/jquery-ui-timepicker-eu.js
+++ b/src/i18n/jquery-ui-timepicker-eu.js
@@ -1,6 +1,6 @@
 /* Basque trannslation for JQuery Timepicker Addon
 /* Translated by Xabi Fer */
-/* Fixed by Asier Iturralde Sarasola - iametza interaktiboa /*
+/* Fixed by Asier Iturralde Sarasola - iametza interaktiboa */
 (function($) {
 	$.timepicker.regional['eu'] = {
 		timeOnlyTitle: 'Aukeratu ordua',


### PR DESCRIPTION
Hi,

I found some small typos in the Basque translation and I fixed them.
Second is "Segundo" in Basque, not "Segundu". For example, http://eu.wikipedia.org/wiki/Segundo

Best regards
