### PR TITLE
Add support for ('setDate', null)

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -1490,11 +1490,11 @@
 						altFormattedDateTime = tp_inst.formattedDate + altSeparator + altFormattedDateTime;
 					}
 				}
-				$(altField).val(altFormattedDateTime);
+				$(altField).val( inst.input.val() ? altFormattedDateTime : "");
 			}
 		}
 		else {
-			$(altField).val( inst.input.val() ? altFormattedDateTime : "");
+			$.datepicker._base_updateAlternate(inst);	
 		}
 	};
 


### PR DESCRIPTION
When ('setDate', null) is called it deletes only date part of alternate field but time still remains.
This patch should fix the problem and properly delete whole alternate field in case that null is set as new date.
