### PR TITLE
Update jquery-ui-timepicker-addon.js

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -1535,7 +1535,8 @@
 		selectLocalTimezone(tp_inst);
 		var now = new Date();
 		this._setTime(inst, now);
-		$('.ui-datepicker-today', $dp).click();
+		this._setDate(inst, now);
+		this._hideDatepicker($(id)[0]);
 	};
 
 	/*


### PR DESCRIPTION
Fixed a big bug on the "go to today" functionnality. When the month is not the current month, the date change didn't work, because the div ".ui-datepicker-today" was not there.
