### PR TITLE
Fix issue with lowercase amNames selector format

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -810,7 +810,7 @@
 						second !== parseInt(this.second,10) || 
 						millisec !== parseInt(this.millisec,10) || 
 						microsec !== parseInt(this.microsec,10) || 
-						(this.ampm.length > 0 && (hour < 12) !== ($.inArray(this.ampm.toUpperCase(), this.amNames) !== -1)) || 
+						(this.ampm.length > 0 && (hour < 12) !== ($.inArray(this.ampm.toUpperCase(), this.amNames.toUpperCase()) !== -1)) || 
 						(this.timezone !== null && timezone !== this.timezone.toString()) // could be numeric or "EST" format, so use toString()
 					);
 

--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -810,7 +810,7 @@
 						second !== parseInt(this.second,10) || 
 						millisec !== parseInt(this.millisec,10) || 
 						microsec !== parseInt(this.microsec,10) || 
-						(this.ampm.length > 0 && (hour < 12) !== ($.inArray(this.ampm.toUpperCase(), this.amNames.toUpperCase()) !== -1)) || 
+						(this.ampm.length > 0 && (hour < 12) !== ($.inArray(this.ampm.toUpperCase(), this.amNames) !== -1)) || 
 						(this.timezone !== null && timezone !== this.timezone.toString()) // could be numeric or "EST" format, so use toString()
 					);
 

--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -1235,7 +1235,7 @@
 						ampm = '';
 						resTime.ampm = '';
 					} else {
-						ampm = $.inArray(treg[order.t].toUpperCase(), o.amNames.toUpperCase()) !== -1 ? 'AM' : 'PM';
+					    ampm = $.inArray(treg[order.t].toUpperCase(), $.map(o.amNames, function (x,i) {return x.toUpperCase() })) !== -1 ? 'AM' : 'PM';
 						resTime.ampm = o[ampm === 'AM' ? 'amNames' : 'pmNames'][0];
 					}
 				}

--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -1235,7 +1235,7 @@
 						ampm = '';
 						resTime.ampm = '';
 					} else {
-						ampm = $.inArray(treg[order.t].toUpperCase(), o.amNames) !== -1 ? 'AM' : 'PM';
+						ampm = $.inArray(treg[order.t].toUpperCase(), o.amNames.toUpperCase()) !== -1 ? 'AM' : 'PM';
 						resTime.ampm = o[ampm === 'AM' ? 'amNames' : 'pmNames'][0];
 					}
 				}


### PR DESCRIPTION
Lowercase amNames selectors ignored and interpreted as PM because of an error in the am selector recognition logic, line 1238, jquery-ui-timepicker-addon.js
This error causes inadvertent change of, for instance, 10 a.m. to 10 p.m. If the user didn't intend to change the date/time in the first place (just oppened and closed the selector) this error can cause the form to be sent with the wrong time. Also note that amNames[0], which is used when wring back to the field is usually in lowercase for i18n files.
Fix: Using the same transformation (toUpperCase) in both sides preserves the equality.

Original:


						ampm = $.inArray(treg[order.t].toUpperCase(), o.amNames) !== -1 ? 'AM' : 'PM';


Proposed:


						ampm = $.inArray(treg[order.t].toUpperCase(), o.amNames.toUpperCase()) !== -1 ? 'AM' : 'PM';



