### PR TITLE
Update AMD dependency to jquery-ui to be standard.

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -9,7 +9,7 @@
 
 (function (factory) {
 	if (typeof define === 'function' && define.amd) {
-		define(['jquery', 'jquery.ui'], factory);
+		define(['jquery', 'jquery-ui'], factory);
 	} else {
 		factory(jQuery);
 	}


### PR DESCRIPTION
The standard naming convention for jQuery UI has a - instead of a .