### PR TITLE
Dev

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -1564,8 +1564,8 @@
 		return $.datepicker._base_doKeyUp(event);
 	};
 
-/*
-	* override "Today" button to also grab the time.
+	/*
+	* override "Today" button to also grab the time and set it to input field.
 	*/
 	$.datepicker._base_gotoToday = $.datepicker._gotoToday;
 	$.datepicker._gotoToday = function (id) {

--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -1564,7 +1564,7 @@
 		return $.datepicker._base_doKeyUp(event);
 	};
 
-	/*
+/*
 	* override "Today" button to also grab the time.
 	*/
 	$.datepicker._base_gotoToday = $.datepicker._gotoToday;
@@ -1577,6 +1577,7 @@
 		now.setMinutes(now.getMinutes() + now.getTimezoneOffset() + tzoffset);
 		this._setTime(inst, now);
 		this._setDate(inst, now);
+		tp_inst._onSelectHandler();
 	};
 
 	/*


### PR DESCRIPTION
After pressing the "Now" button the datetime value didn't went immediately to our property update, but was shown above the datetime picker. Calling the onSelectHandler in _gotoToday solved that problem.