### PR TITLE
Add non-dist files to bower.json ignore property.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,15 @@
 	},
 	"main": ["dist/jquery-ui-timepicker-addon.js", "dist/jquery-ui-timepicker-addon.css"],
 	"ignore": [
+		"/CONTRIBUTING.md",
+		"/Gruntfile.js",
+		"/README.md",
+		"/composer.json",
+		"/jquery-ui-timepicker-addon.json",
+		"/lib",
+		"/package.json",
+		"/src",
+		"/test"
 	],
 	"dependencies": {
 	}


### PR DESCRIPTION
When distributing the package through bower, all build, test, and documenation requirements can be ignored. Users only require the files in dist. Results in a smaller package and faster deployment.