### PR TITLE
Update jquery-ui-timepicker-addon.js

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -717,7 +717,7 @@
 				} else if (this.hour===tempMinTime.getHours() && this.minute<tempMinTime.getMinutes()) {
 					this.minute=this._defaults.minuteMin=tempMinTime.getMinutes();
 				} else {						
-					if (this._defaults.hourMin<tempMinTime.getHours()) {
+					if (this._defaults.hourMin>tempMinTime.getHours()) {
 						this._defaults.hourMin=tempMinTime.getHours();
 						this._defaults.minuteMin=tempMinTime.getMinutes();					
 					} else if (this._defaults.hourMin===tempMinTime.getHours()===this.hour && this._defaults.minuteMin<tempMinTime.getMinutes()) {
@@ -736,7 +736,7 @@
 				} else if (this.hour===tempMaxTime.getHours() && this.minute>tempMaxTime.getMinutes()) {							
 					this.minute=this._defaults.minuteMax=tempMaxTime.getMinutes();						
 				} else {
-					if (this._defaults.hourMax>tempMaxTime.getHours()) {
+					if (this._defaults.hourMax<tempMaxTime.getHours()) {
 						this._defaults.hourMax=tempMaxTime.getHours();
 						this._defaults.minuteMax=tempMaxTime.getMinutes();					
 					} else if (this._defaults.hourMax===tempMaxTime.getHours()===this.hour && this._defaults.minuteMax>tempMaxTime.getMinutes()) {


### PR DESCRIPTION
When not using timeRange method,  it seems to allow two timepickers ("from" and "to" for instance) with minTime and MaxTime interractions working better. I don't know if those changes can have bad effect on the plugin proper working