### PR TITLE
Check for window.console.log.apply for IE old.

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -2229,7 +2229,8 @@
 	 * @return {void}
 	 */
 	$.timepicker.log = function () {
-		if (window.console) {
+		// Older IE (9, maybe 10) throw error on accessing `window.console.log.apply`, so check first.
+		if (window.console && window.console.log && window.console.log.apply) {
 			window.console.log.apply(window.console, Array.prototype.slice.call(arguments));
 		}
 	};


### PR DESCRIPTION
Older IE (9, maybe 10) throw error on accessing `window.console.log.apply`, so check first.