### PR TITLE
Fix TimeZone conversion

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -1713,8 +1713,8 @@
 			if (!tp_inst.support.timezone && tp_inst._defaults.timezone === null) {
 				tp_inst.timezone = tp_date.getTimezoneOffset() * -1;
 			}
-			date = $.timepicker.timezoneAdjust(date, tp_inst.timezone);
-			tp_date = $.timepicker.timezoneAdjust(tp_date, tp_inst.timezone);
+			date = $.timepicker.timezoneAdjust(date, $.timepicker.timezoneOffsetString(-date.getTimezoneOffset()), tp_inst.timezone);
+			tp_date = $.timepicker.timezoneAdjust(tp_date, $.timepicker.timezoneOffsetString(-tp_date.getTimezoneOffset()), tp_inst.timezone);
 		}
 
 		this._updateDatepicker(inst);
@@ -1773,7 +1773,7 @@
 					if (!tp_inst.support.timezone && tp_inst._defaults.timezone === null) {
 						tp_inst.timezone = date.getTimezoneOffset() * -1;
 					}
-					date = $.timepicker.timezoneAdjust(date, tp_inst.timezone);
+					date = $.timepicker.timezoneAdjust(date, tp_inst.timezone, $.timepicker.timezoneOffsetString(-date.getTimezoneOffset()));
 				}
 			}
 			return date;
@@ -2102,13 +2102,15 @@
 	/**
 	 * No way to set timezone in js Date, so we must adjust the minutes to compensate. (think setDate, getDate)
 	 * @param  {Date} date
+	 * @param  {string} fromTimezone formatted like "+0500", "-1245"
 	 * @param  {string} toTimezone formatted like "+0500", "-1245"
 	 * @return {Date}
 	 */
-	$.timepicker.timezoneAdjust = function (date, toTimezone) {
+	$.timepicker.timezoneAdjust = function (date, fromTimezone, toTimezone) {
+		var fromTz = $.timepicker.timezoneOffsetNumber(fromTimezone);
 		var toTz = $.timepicker.timezoneOffsetNumber(toTimezone);
 		if (!isNaN(toTz)) {
-			date.setMinutes(date.getMinutes() + -date.getTimezoneOffset() - toTz);
+			date.setMinutes(date.getMinutes() + (-fromTz) - (-toTz));
 		}
 		return date;
 	};


### PR DESCRIPTION
The issue is caused by different assumptions about current Date object's timezone. Such assumption should not be made within timezoneAdjust as it does not know where the Date object comes from.
For one case, if the Date object is passed in by 'getDate', the Date object has an implied timezone of current TP instance's timezone setting. However, timezoneAdjust would have incorrectly assumed that the Date object's actual timezone is held by date.getTimezoneOffset().

Another issue is that inside timezoneAdjust, the calculation for adjusting Date object is wrong. The minutes should first be adjusted to UTC timezone, by substracting offset; then the resulted minutes can be adjusted to toTimezone, by adding the offset.