### PR TITLE
Fix dutch translation

### DIFF
--- a/src/i18n/jquery-ui-timepicker-nl.js
+++ b/src/i18n/jquery-ui-timepicker-nl.js
@@ -10,7 +10,7 @@
 		millisecText: 'Milliseconde',
 		microsecText: 'Microseconde',
 		timezoneText: 'Tijdzone',
-		currentText: 'Vandaag',
+		currentText: 'Nu',
 		closeText: 'Sluiten',
 		timeFormat: 'HH:mm',
 		timeSuffix: '',


### PR DESCRIPTION
The text 'vandaag' means 'today' which is not accurate enough.
The text 'now' should translate to 'nu'