### PR TITLE
Add support for jQuery UI 1.12 API

### DIFF
--- a/src/jquery-ui-sliderAccess.js
+++ b/src/jquery-ui-sliderAccess.js
@@ -43,8 +43,8 @@
 						$buttons.children('button').each(function(j, jobj){
 							var $jt = $(this);
 							$jt.button({ 
-											text: o.text, 
-											icons: { primary: $jt.data('icon') }
+											showLabel: o.text, 
+											icon: $jt.data('icon')
 										})
 								.click(function(e){
 											var step = $jt.data('step'),
@@ -72,7 +72,7 @@
 						$t[o.where]($buttons);
 
 						if(o.buttonset){
-							$buttons.removeClass('ui-corner-right').removeClass('ui-corner-left').buttonset();
+							$buttons.removeClass('ui-corner-right').removeClass('ui-corner-left').controlgroup();
 							$buttons.eq(0).addClass('ui-corner-left');
 							$buttons.eq(1).addClass('ui-corner-right');
 						}

--- a/src/jquery-ui-timepicker-addon.css
+++ b/src/jquery-ui-timepicker-addon.css
@@ -5,8 +5,10 @@
 .ui-timepicker-div td { font-size: 90%; }
 .ui-tpicker-grid-label { background: none; border: none; margin: 0; padding: 0; }
 .ui-timepicker-div .ui_tpicker_unit_hide{ display: none; }
+/*Fix icon alignment with jQuery UI 1.12*/
+.ui-datepicker .ui-timepicker-div .ui-icon {left: 50%; top: 50%;}
 
-.ui-timepicker-div .ui_tpicker_time .ui_tpicker_time_input { background: none; color: inherit; border: none; outline: none; border-bottom: solid 1px #555; width: 95%; }
+.ui-timepicker-div .ui_tpicker_time .ui_tpicker_time_input { background: none; color: inherit; border: none; outline: none; border-bottom: solid 0 #555; width: 95%; }
 .ui-timepicker-div .ui_tpicker_time .ui_tpicker_time_input:focus { border-bottom-color: #aaa; }
 
 .ui-timepicker-rtl{ direction: rtl; }


### PR DESCRIPTION
> jQuery UI 1.12 introduces API redesigns for Button, Buttonset, Dialog, Draggable, Droppable, Menu, Mouse, Resizable, Selectable, Sortable, Tabs, Tooltip, and Effects. Although the redesigns introduce breaking changes, 1.12 maintains a lot of compatibility with the 1.11 API by default. This is accomplished by rebuilding the 1.11 API on top of the 1.12 API. The default behavior for all 1.12 releases will be to simultaneously use the 1.11 and 1.12 APIs where possible. If you would like to load just the 1.12 API without the 1.11 API, you can set the $.uiBackCompat flag to false.

```
<script src="jquery.js"></script>
<script>$.uiBackCompat = false;</script>
<script src="jquery-ui.js"></script>

I'm using UI lightness Theme and i noticed that the icon used in the combo to open the dropdown ".ui-icon-triangle-1-s" is moved one pixel to left, so to set icon to the same exact position as before you'll have to update jQuery UI stylesheet accordingly.

```
