### PR TITLE
IE11 Unspecified error

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -888,7 +888,7 @@
 				else {
 					this.$timeObj.val($.datepicker.formatTime(pickerTimeFormat, this, o) + pickerTimeSuffix);
 				}
-				if (this.$timeObj[0].setSelectionRange) {
+				if (this.$timeObj[0].setSelectionRange && this.$timeObj.is(":visible")) {
 					var sPos = this.$timeObj[0].selectionStart;
 					var ePos = this.$timeObj[0].selectionEnd;
 					this.$timeObj[0].setSelectionRange(sPos, ePos);


### PR DESCRIPTION
Hi @trentrichardson,
 
When calling setSelectionRange on an input element which is currently not
visible, you get an unspecified error in IE11.

I added a little check for this.

Fixes #848 