### PR TITLE
FIX: HTML5 has fixed time format HH:mm:ss, ...

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -166,6 +166,7 @@
 		*/
 		setDefaults: function (settings) {
 			extendRemove(this._defaults, settings || {});
+			this._defaults.timeFormat = 'HH:mm:ss';
 			return this;
 		},
 


### PR DESCRIPTION
Otherwise browsers that support it don't recognize default value