### PR TITLE
Removed BOM encoding

### DIFF
--- a/dist/i18n/jquery-ui-timepicker-hu.js
+++ b/dist/i18n/jquery-ui-timepicker-hu.js
@@ -1,4 +1,4 @@
-﻿/* Hungarian translation for the jQuery Timepicker Addon */
+/* Hungarian translation for the jQuery Timepicker Addon */
 /* Written by Vas Gábor */
 (function($) {
 	$.timepicker.regional['hu'] = {

--- a/src/i18n/jquery-ui-timepicker-hu.js
+++ b/src/i18n/jquery-ui-timepicker-hu.js
@@ -1,4 +1,4 @@
-﻿/* Hungarian translation for the jQuery Timepicker Addon */
+/* Hungarian translation for the jQuery Timepicker Addon */
 /* Written by Vas Gábor */
 (function($) {
 	$.timepicker.regional['hu'] = {


### PR DESCRIPTION
UTF-BOM encoding can cause strange errors when the files are not decoded properly. Ive re-encoded these files to UTF, a much more common standard.