### PR TITLE
Replace eval() with new Function()

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -183,7 +183,7 @@
 					var attrValue = $input.attr('time:' + attrName);
 					if (attrValue) {
 						try {
-							inlineSettings[attrName] = eval(attrValue);
+							inlineSettings[attrName] = (new Function('return ('+attrValue+')'))();
 						} catch (err) {
 							inlineSettings[attrName] = attrValue;
 						}


### PR DESCRIPTION
Replace 
```js
eval(attrValue)
```
with
```js
(new Function('return ('+attrValue+')'))()
```

### Why?

`eval()` is evaluated in the scope where it is called, which exposes all the (private) variables to the string script being evaluated.
Besides security considerations, it disables mangling of all variables names in the scope (and all parent scopes) during code minification, because every variable could be potentially used in the `eval()`.

The `(new Function(str))()` approach is much safer, cause it does not have access to the current scope.