### PR TITLE
Fixed wrong translation for "currentText" on Spanish localization file.

### DIFF
--- a/dist/i18n/jquery-ui-timepicker-es.js
+++ b/dist/i18n/jquery-ui-timepicker-es.js
@@ -11,7 +11,7 @@
 		millisecText: 'Milisegundos',
 		microsecText: 'Microsegundos',
 		timezoneText: 'Uso horario',
-		currentText: 'Hoy',
+		currentText: 'Ahora',
 		closeText: 'Cerrar',
 		timeFormat: 'HH:mm',
 		timeSuffix: '',


### PR DESCRIPTION
The "currentText" translation in Spanish read "Hoy", which means "Today" (as it is on standard datepicker by default). It has been corrected to "Ahora" ("Now") following the pattern described on the timepicker add-on documentation.