### PR TITLE
Fixed translation for "timezoneText" on Spanish localization file

### DIFF
--- a/dist/i18n/jquery-ui-timepicker-es.js
+++ b/dist/i18n/jquery-ui-timepicker-es.js
@@ -10,7 +10,7 @@
 		secondText: 'Segundos',
 		millisecText: 'Milisegundos',
 		microsecText: 'Microsegundos',
-		timezoneText: 'Uso horario',
+		timezoneText: 'Zona horaria',
 		currentText: 'Hoy',
 		closeText: 'Cerrar',
 		timeFormat: 'HH:mm',


### PR DESCRIPTION
The translation for "timezoneText" on Spanish read "Uso horario". Besides this being a typo (right expression is "Huso horario"), the expression "Zona horaria" is much more common.